### PR TITLE
For time-varying mgm models bwSelect always errors when updating progress bar

### DIFF
--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -285,7 +285,7 @@ bwSelect <- function(data,
 
 
       # Update Progress Bar
-      if(args$pbar==TRUE) setTxtProgressBar(pb_bw, i)
+      if(pbar==TRUE) setTxtProgressBar(pb_bw, i)
 
     }
 


### PR DESCRIPTION
For time varying mgm models, `bwSelect()` would always fail because the conditional test for whether to [update the progress bar](https://github.com/jmbh/mgm/blob/master/R/bwSelect.R#L220) used `args$pbar` yet `pbar` is not in list `args` (created from the `...` args supplied, if any).

```r
# Update Progress Bar
if(args$pbar==TRUE) setTxtProgressBar(pb_bw, i)
```

This PR changes this one line of code to refer directly to the `pbar` object:

```r
# Update Progress Bar
if(pbar==TRUE) setTxtProgressBar(pb_bw, i)
```