### PR TITLE
Parallelize mgm

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\tvmgm_Gaussian_example

--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -19,6 +19,7 @@ bwSelect <- function(data,
   args <- list(...)
   
   if(is.null(args$mgm_par)) args$mgm_par <- TRUE
+  if(is.null(args$tvmgm_par)) args$tvmgm_par <- FALSE
   
   # Input checks specific for mvar()
   if(modeltype == 'mvar') {
@@ -266,6 +267,7 @@ bwSelect <- function(data,
                                     saveModels = TRUE, # otherwise we can't make predictions
                                     signInfo = FALSE,
                                     mgm_par = args$mgm_par,
+                                    tvmgm_par = args$tvmgm_par,
                                     ...)
 
         

--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -17,7 +17,9 @@ bwSelect <- function(data,
   # -------------------- Input Checks -------------------
 
   args <- list(...)
-
+  
+  if(is.null(args$mgm_par)) args$mgm_par <- TRUE
+  
   # Input checks specific for mvar()
   if(modeltype == 'mvar') {
     if(is.null(args$lags)) stop('No lags specified')
@@ -263,7 +265,7 @@ bwSelect <- function(data,
                                     zero_weights = l_zero_weights[[fold]], # vector indicating zero weights for test cases
                                     saveModels = TRUE, # otherwise we can't make predictions
                                     signInfo = FALSE,
-                                    mgm_par = TRUE,
+                                    mgm_par = args$mgm_par,
                                     ...)
 
         

--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -13,7 +13,9 @@ bwSelect <- function(data,
 
 
 {
-
+  
+  message("mgm-parallel")
+  
   # -------------------- Input Checks -------------------
 
   args <- list(...)

--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -14,8 +14,6 @@ bwSelect <- function(data,
 
 {
   
-  message("mgm-parallel")
-  
   # -------------------- Input Checks -------------------
 
   args <- list(...)

--- a/R/bwSelect.R
+++ b/R/bwSelect.R
@@ -265,6 +265,7 @@ bwSelect <- function(data,
                                     zero_weights = l_zero_weights[[fold]], # vector indicating zero weights for test cases
                                     saveModels = TRUE, # otherwise we can't make predictions
                                     signInfo = FALSE,
+                                    mgm_par = TRUE,
                                     ...)
 
         

--- a/R/mgm.R
+++ b/R/mgm.R
@@ -1,32 +1,32 @@
 
-mgm <- function(data,         # n x p data matrix
-                type,         # p vector indicating the type of each variable
-                level,        # p vector indivating the levels of each variable
-                lambdaSeq,    # sequence of considered lambda values (default to glmnet default)
-                lambdaSel,    # way of selecting lambda: CV vs. EBIC
-                lambdaFolds,  # number of folds if lambdaSel = 'CV'
-                lambdaGam,    # EBIC hyperparameter gamma, if lambdaSel = 'EBIC'
-                alphaSeq,     # sequence of considered alpha values (elastic net), default = 1 = lasso
-                alphaSel,     # way of selecting lambda: CV vs. EBIC
-                alphaFolds,   # number of folds if alphaSel = 'CV'
-                alphaGam,     # EBIC hyperparameter gamma, if alphaSel = 'EBIC',
-                k,            # order of modeled interactions, 1 = pairwise
-                moderators,   # Vector specifying first-order moderators to be included in the model
-                ruleReg,      # rule to combine d+1 neighborhood estimates (defaults to 'AND')
-                weights,      # p vector of observation weights for weighted regression
-                threshold,    # defaults to 'LW', see helpfile
-                method,       # glm vs. 'linear'; for now only implement glm
-                binarySign,   # should a sign be computed for binary models (defaults to NO)
-                scale,        # should gaussian variables be scaled? defaults to TRYE
-                verbatim,     # turns off all notifications
-                pbar,         #
-                warnings,     #
-                saveModels,   # defaults to TRUE, saves all estimated models
-                saveData,     # defaults to FALSE, saves the data, =TRUE makes sense for easier prediction routine in predict.mgm()
-                overparameterize, # if TRUE, uses the over-parameterized version,
-                thresholdCat, # TRUE if overparameterize=FALSE; FALSE if overparamterize=TRUE; this argument overwrites this
-                signInfo,
-                ...
+mgm.par <- function(data,         # n x p data matrix
+                    type,         # p vector indicating the type of each variable
+                    level,        # p vector indivating the levels of each variable
+                    lambdaSeq,    # sequence of considered lambda values (default to glmnet default)
+                    lambdaSel,    # way of selecting lambda: CV vs. EBIC
+                    lambdaFolds,  # number of folds if lambdaSel = 'CV'
+                    lambdaGam,    # EBIC hyperparameter gamma, if lambdaSel = 'EBIC'
+                    alphaSeq,     # sequence of considered alpha values (elastic net), default = 1 = lasso
+                    alphaSel,     # way of selecting lambda: CV vs. EBIC
+                    alphaFolds,   # number of folds if alphaSel = 'CV'
+                    alphaGam,     # EBIC hyperparameter gamma, if alphaSel = 'EBIC',
+                    k,            # order of modeled interactions, 1 = pairwise
+                    moderators,   # Vector specifying first-order moderators to be included in the model
+                    ruleReg,      # rule to combine d+1 neighborhood estimates (defaults to 'AND')
+                    weights,      # p vector of observation weights for weighted regression
+                    threshold,    # defaults to 'LW', see helpfile
+                    method,       # glm vs. 'linear'; for now only implement glm
+                    binarySign,   # should a sign be computed for binary models (defaults to NO)
+                    scale,        # should gaussian variables be scaled? defaults to TRYE
+                    verbatim,     # turns off all notifications
+                    pbar,         #
+                    warnings,     #
+                    saveModels,   # defaults to TRUE, saves all estimated models
+                    saveData,     # defaults to FALSE, saves the data, =TRUE makes sense for easier prediction routine in predict.mgm()
+                    overparameterize, # if TRUE, uses the over-parameterized version,
+                    thresholdCat, # TRUE if overparameterize=FALSE; FALSE if overparamterize=TRUE; this argument overwrites this
+                    signInfo,
+                    ...
 )
 
 {
@@ -553,6 +553,548 @@ mgm <- function(data,         # n x p data matrix
   
 } # eoF
 
+mgm <- function(data,         # n x p data matrix
+                type,         # p vector indicating the type of each variable
+                level,        # p vector indivating the levels of each variable
+                lambdaSeq,    # sequence of considered lambda values (default to glmnet default)
+                lambdaSel,    # way of selecting lambda: CV vs. EBIC
+                lambdaFolds,  # number of folds if lambdaSel = 'CV'
+                lambdaGam,    # EBIC hyperparameter gamma, if lambdaSel = 'EBIC'
+                alphaSeq,     # sequence of considered alpha values (elastic net), default = 1 = lasso
+                alphaSel,     # way of selecting lambda: CV vs. EBIC
+                alphaFolds,   # number of folds if alphaSel = 'CV'
+                alphaGam,     # EBIC hyperparameter gamma, if alphaSel = 'EBIC',
+                k,            # order of modeled interactions, 1 = pairwise
+                moderators,   # Vector specifying first-order moderators to be included in the model
+                ruleReg,      # rule to combine d+1 neighborhood estimates (defaults to 'AND')
+                weights,      # p vector of observation weights for weighted regression
+                threshold,    # defaults to 'LW', see helpfile
+                method,       # glm vs. 'linear'; for now only implement glm
+                binarySign,   # should a sign be computed for binary models (defaults to NO)
+                scale,        # should gaussian variables be scaled? defaults to TRYE
+                verbatim,     # turns off all notifications
+                pbar,         #
+                warnings,     #
+                saveModels,   # defaults to TRUE, saves all estimated models
+                saveData,     # defaults to FALSE, saves the data, =TRUE makes sense for easier prediction routine in predict.mgm()
+                overparameterize, # if TRUE, uses the over-parameterized version,
+                thresholdCat, # TRUE if overparameterize=FALSE; FALSE if overparamterize=TRUE; this argument overwrites this
+                signInfo,
+                ...
+)
+
+{
+  
+  # --------------------------------------------------------------------------------------------
+  # -------------------- Input Checks ----------------------------------------------------------
+  # --------------------------------------------------------------------------------------------
+  
+  # ----- Compute Auxilliary Variables I -----
+  
+  p <- ncol(data)
+  n <- nrow(data)
+  data <- as.matrix(data)
+  
+  # Give Names to variables (Needed to use formula to construct design matrix and to give informative error messages)
+  colnames(data)[1:p] <- paste("V", 1:p, '.', sep = "")
+  # colnames(data)[type == 'c'] <- paste("V", (1:p)[type == 'c'], '.', sep = "") # dot deliminator for categorical variables; needed to identify parameters assiciated with some k-order interaction below
+  
+  # Catch other passed on arguments
+  args <- list(...)
+  
+  # ----- Fill in Defaults -----
+  
+  if(missing(lambdaSeq)) lambdaSeq <- NULL
+  if(missing(lambdaSel)) lambdaSel <- 'CV'
+  if(missing(lambdaFolds)) lambdaFolds <- 10
+  if(missing(lambdaGam)) lambdaGam <- .25
+  if(missing(alphaSeq)) alphaSeq <- 1
+  if(missing(alphaSel)) alphaSel <- 'CV'
+  if(missing(alphaFolds)) alphaFolds <- 10
+  if(missing(alphaGam)) alphaGam <- .25
+  if(missing(k)) k <- 2
+  if(missing(moderators)) moderators <- NULL
+  if(missing(ruleReg)) ruleReg <- 'AND'
+  if(missing(weights)) weights <- rep(1, n)
+  if(missing(threshold)) threshold <- 'LW'
+  if(missing(method)) method <- 'glm'
+  if(missing(binarySign)) {
+    if(!is.null(args$binary.sign)) binarySign <- args$binary.sign else binarySign <- FALSE
+  }
+  
+  if(!is.null(args$binary.sign)) {
+    warning("The argument 'binary.sign' is deprecated Use 'binarySign' instead.")
+  }
+  
+  
+  if(missing(scale)) scale <- TRUE
+  if(missing(verbatim)) verbatim <- FALSE
+  if(missing(pbar)) pbar <- TRUE
+  if(missing(warnings)) warnings <- TRUE
+  if(missing(saveModels)) saveModels <- TRUE
+  if(missing(saveData)) saveData <- FALSE
+  if(missing(overparameterize)) overparameterize <- FALSE
+  if(missing(signInfo)) signInfo <- TRUE
+  if(missing(thresholdCat)) if(overparameterize) thresholdCat <- TRUE else thresholdCat <- TRUE # always better
+  
+  if(verbatim) pbar <- FALSE
+  if(verbatim) warnings <- FALSE
+  
+  # Switch all warnings off
+  if(!warnings) {
+    oldw <- getOption("warn")
+    options(warn = -1)
+  }
+  
+  # ----- Basic Checks I -----
+  
+  # Checks on data
+  if(nrow(data) < 2) ('The data matrix has to have at least 2 rows.')
+  if(any(!(apply(data, 2, class) %in% c('numeric', 'integer')))) stop('Only integer and numeric values permitted.')
+  if(missing(data)) stop('No data provided.')
+  if(any(!is.finite(as.matrix(data)))) stop('No infinite values permitted.')
+  if(any(is.na(data))) stop('No missing values permitted.')
+  
+  # browser()
+  
+  # Checks on moderators
+  if(!is.null(moderators)) {
+    if(k>2) stop("Please specify higher order interactions eithere with the  argument or the moderators argument.")
+    if(!all(moderators == round(moderators))) stop("Moderators have to be specified as integers mapping to the column numbers of variables in the data set.")
+    if(!all(moderators %in% 1:p)) stop("Specified moderators are larger than number of variables in the data.")
+    if(class(moderators)[1] == "matrix") if(ncol(moderators) != 3) stop("Custom moderators have to be specified in a M x 3 matrix, for M moderators.")
+    if(is.matrix(moderators)) if(any(apply(moderators, 1, function(x) any(duplicated(x))))) stop("Currently mgm() does not support the specification of quadratic effects.")
+  } # end if: moderators?
+  
+  
+  
+  
+  # ----- Compute Auxilliary Variables II -----
+  
+  # From k to d
+  d <- k - 1 # k = largest order of interaction in joint model; d = largest neighborhood size
+  
+  # Empirical Levels of each variable
+  emp_lev <- rep(NA, p)
+  ind_cat <- which(type=='c')
+  if(length(ind_cat)>0) for(i in 1:length(ind_cat)) emp_lev[ind_cat][i] <-  length(unique(data[,ind_cat[i]])) # no apply() because of case of 1 categorical
+  emp_lev[which(type!='c')] <- 1
+  
+  if(!missing(level)) {
+    # Check whether provided levels are equal to levels in the data
+    level_check <- level != emp_lev
+    if(sum(level_check) > 0) stop(paste0('Provided levels not equal to levels in data for variables ',paste((1:p)[level_check], collapse = ', ')))
+    # if not provided, do nothing, because the argument is not actually necessary
+  }
+  level <- emp_lev
+  
+  # Normalize weights (necessary to ensure that nadj makes sense)
+  if(!missing(weights)) weights <- weights / max(weights)
+  nadj <- sum(weights) # calc adjusted n
+  
+  # Scale Gaussians
+  ind_Gauss <- which(type == 'g')
+  if(scale) for(i in ind_Gauss) data[, i] <- scale(data[, i])
+  
+  
+  # Get unique values for all categorical variables (used in condition.R)
+  unique_cats <- list()
+  for(i in 1:p) if(type[i]=="c") unique_cats[[i]] <- unique(data[, i])
+  
+  # ----- Basic Checks II -----
+  
+  # Checks on other arguments
+  if(!(threshold %in% c('none', 'LW', 'HW'))) stop('Please select one of the three threshold options "HW", "LW" and "none" ')
+  if(k<2) stop('The order of interactions should be at least k = 2 (pairwise interactions)')
+  if(ncol(data)<3) stop('At least 3 variables required')
+  if(missing(type)) stop('No type vector provided.')
+  if(sum(!(type %in% c('g', 'c', 'p')))>0) stop("Only Gaussian 'g', Poisson 'p' or categorical 'c' variables permitted.")
+  if(ncol(data) != length(type)) stop('Number of variables is not equal to length of type vector.')
+  if(!missing(level)) if(ncol(data) != length(level)) stop('Number of variables is not equal to length of level vector.')
+  if(nrow(data) != length(weights)) stop('Number of observations is not equal to length of weights vector.')
+  if(!is.null(moderators) & k > 2) stop("Moderator specification is only implemented for first-order moderation (3-way interactions). See ?mgm")
+  
+  # Are Poisson variables integers?
+  if('p' %in% type) {
+    ind_Pois <- which(type == 'p')
+    nPois <- length(ind_Pois)
+    v_PoisCheck <- rep(NA, length=nPois)
+    for(i in 1:nPois) v_PoisCheck[i] <- sum(data[, ind_Pois[i]] != round(data[, ind_Pois[i]])) > 0
+    if(sum(v_PoisCheck) > 0) stop('Only integers permitted for Poisson variables.')
+  }
+  
+  
+  # ----- Checking glmnet minimum Variance requirements -----
+  
+  glmnetRequirements(data = data,
+                     type = type,
+                     weights = weights)
+  
+  
+  
+  # ----- Binary Sign => values have to be in {0,1} -----
+  
+  # compute anyway, because used later for sign extraction
+  
+  # Find the binary variables
+  ind_cat <- which(type == 'c')
+  ind_binary <- rep(NA, length(ind_cat))
+  ind_binary <- as.logical(ind_binary)
+  if(length(ind_cat)>0) {
+    for(i in 1:length(ind_cat)) ind_binary[i] <- length(unique(data[, ind_cat[i]])) == 2
+  }
+  
+  # Check if they are coded in {0,1}
+  if(sum(ind_binary)>0){
+    check_binary <- rep(NA, sum(ind_binary))
+    for(i in 1:sum(ind_binary)) check_binary[i] <- sum(!(unique(data[, ind_cat[ind_binary][i]]) %in% c(0,1)))
+    
+    if(binarySign) {
+      if(sum(check_binary)>0) stop(paste0('If binarySign = TRUE, all binary variables have to be coded {0,1}. Not satisfied in variable(s) ',paste(ind_cat[ind_binary][check_binary>0], collapse = ', ')))
+    }
+  }
+  
+  
+  # --------------------------------------------------------------------------------------------
+  # -------------------- Create Output Objects -------------------------------------------------
+  # --------------------------------------------------------------------------------------------
+  
+  
+  # ----- Storage: Create empty mgm object -----
+  
+  mgmobj <- list('call' = NULL,
+                 'pairwise' = list('wadj' = NULL,
+                                   'signs' = NULL,
+                                   'edgecolor'= NULL, 
+                                   "wadjNodewise" = NULL,
+                                   "signsNodewise" = NULL,
+                                   "edgecolorNodewise" = NULL),
+                 'interactions' = list('indicator' = NULL,
+                                       'weightsAgg' = NULL,
+                                       'weights' = NULL,
+                                       'signs' = NULL),
+                 'intercepts' = NULL,
+                 'nodemodels' = list())
+  
+  
+  # ----- Save the Call -----
+  
+  
+  mgmobj$call <- list('data' = NULL,
+                      'type' = type,
+                      'level' = level,
+                      "levelNames" = NULL,
+                      'lambdaSeq' = lambdaSeq,
+                      'lambdaSel' = lambdaSel,
+                      'lambdaFolds' = lambdaFolds,
+                      'lambdaGam' = lambdaGam,
+                      'alphaSeq' = alphaSeq,
+                      'alphaSel' = alphaSel,
+                      'alphaFolds' = alphaFolds,
+                      'alphaGam' = alphaGam,
+                      'k' = k,
+                      "moderators" = moderators, 
+                      'ruleReg' = ruleReg,
+                      'weights' = weights,
+                      'threshold' = threshold,
+                      'method' = method,
+                      'binarySign' = binarySign,
+                      'scale' = scale,
+                      'verbatim' = verbatim,
+                      'pbar' = pbar,
+                      'warnings' = warnings,
+                      'saveModels' = saveModels,
+                      'saveData' = saveData,
+                      'overparameterize' = overparameterize,
+                      "thresholdCat" = thresholdCat,
+                      "signInfo" = signInfo, 
+                      "npar"=NULL,
+                      "n"=nrow(data), 
+                      "ind_cat" = ind_cat, 
+                      "ind_binary" = ind_binary, 
+                      "unique_cats" = unique_cats)
+  
+  if(saveData) mgmobj$call$data <- data
+  
+  
+  # ----- Some more variable Transforms -----
+  
+  data <- as.data.frame(data)
+  
+  # Categoricals into factors (Needed to use formula to construct design matrix)
+  for(i in which(type=='c')) data[, i] <- as.factor(data[, i])
+  
+  
+  # --------------------------------------------------------------------------------------------
+  # -------------------- Nodewise Estimation ---------------------------------------------------
+  # --------------------------------------------------------------------------------------------
+  
+  
+  # Progress bar
+  if(pbar==TRUE) pb <- txtProgressBar(min = 0, max=p, initial=0, char="-", style = 3)
+  
+  # Save number of parameters of standard (non-overparameterized) design matrices for tau threshold
+  npar_standard <- rep(NA, p)
+  
+  l_mods_ind <- list() # collect moderator terms for later output-processing
+  
+  for(v in 1:p) {
+    
+    # ----- Construct Design Matrix -----
+    
+    X_standard <- X <- ModelMatrix_standard(data = data,
+                                            type = type,
+                                            d = d, 
+                                            v = v, 
+                                            moderators = moderators)
+    
+    npar_standard[v] <- ncol(X_standard)
+    
+    
+    if(overparameterize) {
+      
+      X_over <- ModelMatrix(data = data, # fix that input, that's stupid
+                            type = type,
+                            level = level,
+                            labels = colnames(data),
+                            d = d, 
+                            moderators = moderators,
+                            v = v)
+      
+      X <- X_over
+      
+    } # end if: overparameterize?
+    
+    
+    ## Scale Gaussian variables AFTER computing design matrix
+    # Compute vector that tell us which interactions are purely consisting of continuous variables?
+    if(scale) {
+      if(any(type == "g")) {
+        cn <- colnames(X)
+        l_ints_split <- strsplit(cn, ":")
+        ind_allc <- unlist(lapply(l_ints_split, function(x) {
+          x2 <- sub("V", "", x)
+          vars <- as.numeric(unlist(lapply(strsplit(x2, "[.]"), function(y) y[1] )))
+          all(type[vars] == "g")
+        }))
+        
+        X[, ind_allc] <- apply(matrix(X[, ind_allc], ncol = sum(ind_allc)), 2, scale)
+      }
+    }
+    
+    # Response 
+    y <- as.numeric(data[, v])
+    
+    
+    # ----- Tuning Parameter Selection (lambda and alpha) -----
+    
+    n_alpha <- length(alphaSeq) # length of alpha sequence
+    
+    # alpha Section via CV
+    
+    if(alphaSel == 'CV') {
+      
+      l_alphaModels <- list() # Storage
+      ind <- sample(1:alphaFolds, size = n, replace = TRUE) # fold-indicators, use same for each alpha
+      
+      v_mean_OOS_deviance <- rep(NA, n_alpha)
+      
+      if(n_alpha>1) {
+        
+        
+        # For: alpha
+        for(a in 1:n_alpha) {
+          
+          l_foldmodels <- list()
+          v_OOS_deviance <- rep(NA, alphaFolds)
+          
+          for(fold in 1:alphaFolds) {
+            
+            # Select training and test sets
+            train_X <- X[ind != fold, ]
+            train_y <- y[ind != fold]
+            test_X <- X[ind == fold, ]
+            test_y <- y[ind == fold]
+            
+            # Recompute variables for training set
+            n_train <- nrow(train_X)
+            nadj_train <- sum(weights[ind != fold])
+            
+            
+            l_foldmodels[[fold]] <- nodeEst(y = train_y,
+                                            X = train_X,
+                                            lambdaSeq = lambdaSeq,
+                                            lambdaSel = lambdaSel,
+                                            lambdaFolds = lambdaFolds,
+                                            lambdaGam = lambdaGam,
+                                            alpha = alphaSeq[a],
+                                            weights = weights[ind != fold],
+                                            n = n_train,
+                                            nadj = nadj_train,
+                                            v = v,
+                                            type = type,
+                                            level = level,
+                                            emp_lev = emp_lev,
+                                            overparameterize = overparameterize,
+                                            thresholdCat = thresholdCat)
+            
+            
+            # Calculte Out-of-sample deviance for current fold
+            LL_model <- calcLL(X = test_X,
+                               y = test_y,
+                               fit = l_foldmodels[[fold]]$fitobj,
+                               type = type,
+                               level = level,
+                               v = v,
+                               weights = weights[ind == fold],
+                               lambda = l_foldmodels[[fold]]$lambda,
+                               LLtype = 'model')
+            
+            LL_saturated <- calcLL(X = test_X,
+                                   y = test_y,
+                                   fit = l_foldmodels[[fold]]$fitobj,
+                                   type = type,
+                                   level = level,
+                                   v = v,
+                                   weights = weights[ind == fold],
+                                   lambda = l_foldmodels[[fold]]$lambda,
+                                   LLtype = 'saturated')
+            
+            v_OOS_deviance[fold] <- 2 * (LL_saturated - LL_model)
+            
+          }
+          
+          v_mean_OOS_deviance[a] <- mean(v_OOS_deviance)
+          
+        }
+        
+        alpha_select <- alphaSeq[which.min(v_mean_OOS_deviance)]
+        
+        
+        # If there is no search for alpha, goes continue and use default alpha
+      } else {
+        
+        alpha_select <- alphaSeq # in case alpha is just specified
+        
+      }
+      
+      # Refit Model on whole data, with selected alpha
+      
+      # browser()
+      
+      model <- nodeEst(y = y,
+                       X = X,
+                       lambdaSeq = lambdaSeq,
+                       lambdaSel = lambdaSel,
+                       lambdaFolds = lambdaFolds,
+                       lambdaGam = lambdaGam,
+                       alpha = alpha_select,
+                       weights = weights,
+                       n = n,
+                       nadj = nadj,
+                       v = v,
+                       type = type,
+                       level= level,
+                       emp_lev = emp_lev,
+                       overparameterize = overparameterize,
+                       thresholdCat = thresholdCat)
+      
+      mgmobj$nodemodels[[v]] <- model
+      
+    }
+    
+    
+    # alpha Section via EBIC
+    
+    if(alphaSel == 'EBIC') {
+      
+      l_alphaModels <- list()
+      EBIC_Seq <- rep(NA, n_alpha)
+      
+      # For: alpha
+      for(a in 1:n_alpha) {
+        
+        
+        l_alphaModels[[a]] <- nodeEst(y = y,
+                                      X = X,
+                                      lambdaSeq = lambdaSeq,
+                                      lambdaSel = lambdaSel,
+                                      lambdaFolds = lambdaFolds,
+                                      lambdaGam = lambdaGam,
+                                      alpha = alphaSeq[a],
+                                      weights = weights,
+                                      n = n,
+                                      nadj = nadj,
+                                      v = v,
+                                      type = type,
+                                      level = level,
+                                      emp_lev = emp_lev, 
+                                      overparameterize = overparameterize,
+                                      thresholdCat = thresholdCat)
+        
+        EBIC_Seq[a] <- l_alphaModels[[a]]$EBIC
+        
+      }
+      
+      ind_minEBIC_model <- which.min(EBIC_Seq)
+      mgmobj$nodemodels[[v]] <- l_alphaModels[[ind_minEBIC_model]]
+      
+      
+    } # end if: alpha EBIC?
+    
+    
+    # Update Progress Bar
+    if(pbar==TRUE) setTxtProgressBar(pb, v)
+    
+  } # end for: p
+  
+  mgmobj$call$npar <- npar_standard
+  
+  
+  # --------------------------------------------------------------------------------------------
+  # -------------------- Processing glmnet output ----------------------------------------------
+  # --------------------------------------------------------------------------------------------  
+  
+  mgmobj <- Reg2Graph(mgmobj = mgmobj)
+  
+  
+  # --------------------------------------------------------------------------------------------
+  # -------------------- Output ----------------------------------------------------------------
+  # --------------------------------------------------------------------------------------------
+  
+  
+  # Save Node Models and extracted raw factors?
+  if(!saveModels) {
+    mgmobj$nodemodels <- NULL
+    mgmobj$factors <- NULL
+  }
+  
+  # Switch warnings back on
+  if(!warnings) {
+    options(warn = oldw)
+  }
+  
+  if(pbar) {
+    if(signInfo) cat('\nNote that the sign of parameter estimates is stored separately; see ?mgm')    
+  } else {
+    if(signInfo) cat('Note that the sign of parameter estimates is stored separately; see ?mgm')    
+  }
+  
+  # Return level names (used in showInteraction())
+  levelNames <- list()
+  for(i in 1:p) {
+    if(type[i] == "c") levelNames[[i]] <- sort(as.numeric(as.character(unique(data[, i])))) else levelNames[[i]] <- NA
+  }
+  
+  mgmobj$call$levelNames <- levelNames
+  
+  # Assign class
+  class(mgmobj) <- c('mgm', 'core')
+  
+  return(mgmobj)
+  
+  
+} # eoF
 
 
 

--- a/R/startup_msg.R
+++ b/R/startup_msg.R
@@ -3,6 +3,7 @@
 .onAttach <- function(libname, pkgname) {
   version <- read.dcf(file=system.file("DESCRIPTION", package=pkgname),
                       fields="Version")
+  pkgname <- paste0(pkgname, "-parallel")
   packageStartupMessage("This is ",paste(pkgname, version))
   packageStartupMessage("Please report issues on Github: https://github.com/jmbh/mgm/issues")
 }

--- a/R/startup_msg.R
+++ b/R/startup_msg.R
@@ -4,6 +4,6 @@
   version <- read.dcf(file=system.file("DESCRIPTION", package=pkgname),
                       fields="Version")
   pkgname <- paste0(pkgname, "-parallel")
-  packageStartupMessage("This is ",paste(pkgname, version))
-  packageStartupMessage("Please report issues on Github: https://github.com/jmbh/mgm/issues")
+  packageStartupMessage("This is ", pkgname)
+  packageStartupMessage("A parallel version of the mgm package")
 }

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -25,7 +25,7 @@ tvmgm <- function(data,         # n x p data matrix
 
   # ----- Fill in Defaults -----
   
-  if(is.null(args$mgm_par)) args$mgm_par <- FALSE
+  if(is.null(args$mgm_par)) args$mgm_par <- TRUE
   
   if(is.null(args$lambdaSeq)) args$lambdaSeq <- NULL
   if(is.null(args$lambdaSel)) args$lambdaSel <- 'EBIC'
@@ -201,38 +201,40 @@ tvmgm <- function(data,         # n x p data matrix
   
   }else{
     
-    # otherwise, parallelize along the est_points
-    l_tvmgm_models <- foreach::`%dopar%`(
-      foreach::foreach(i = 1:no_estpoints, .packages = "mgm"),
-      {
-        mgm(data = data,
-            type = type,
-            level = level,
-            lambdaSeq = args$lambdaSeq,
-            lambdaSel = args$lambdaSel,
-            lambdaFolds = args$lambdaFolds,
-            lambdaGam = args$lambdaGam,
-            alphaSeq = args$alphaSeq,
-            alphaSel = args$alphaSel,
-            alphaFolds = args$alphaFolds,
-            alphaGam = args$alphaGam,
-            k = args$k,
-            ruleReg = args$ruleReg,
-            weights = l_weights[[i]],
-            threshold = args$threshold,
-            method = args$method,
-            binarySign = args$binarySign,
-            scale = args$scale,
-            verbatim = args$verbatim,
-            pbar = FALSE,
-            warnings = args$warnings,
-            saveModels = args$saveModels,
-            saveData = args$saveData,
-            overparameterize = args$overparameterize,
-            signInfo = FALSE) # to avoid msg for each model
-        
-        }) # End for: timepoints
-    }
+    # otherwise run each mgm sequentially
+    for(i in 1:no_estpoints) {
+      
+      l_tvmgm_models[[i]] <- mgm(data = data,
+                                 type = type,
+                                 level = level,
+                                 lambdaSeq = args$lambdaSeq,
+                                 lambdaSel = args$lambdaSel,
+                                 lambdaFolds = args$lambdaFolds,
+                                 lambdaGam = args$lambdaGam,
+                                 alphaSeq = args$alphaSeq,
+                                 alphaSel = args$alphaSel,
+                                 alphaFolds = args$alphaFolds,
+                                 alphaGam = args$alphaGam,
+                                 k = args$k,
+                                 ruleReg = args$ruleReg,
+                                 weights = l_weights[[i]],
+                                 threshold = args$threshold,
+                                 method = args$method,
+                                 binarySign = args$binarySign,
+                                 scale = args$scale,
+                                 verbatim = args$verbatim,
+                                 pbar = FALSE,
+                                 warnings = args$warnings,
+                                 saveModels = args$saveModels,
+                                 saveData = args$saveData,
+                                 overparameterize = args$overparameterize,
+                                 signInfo = FALSE) # to avoid msg for each model
+      
+      # Update Progress Bar
+      if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+      
+    } # End for: timepoints
+  }
   
   # Save into output list
   tvmgmobj$tvmodels <- l_tvmgm_models

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -26,6 +26,7 @@ tvmgm <- function(data,         # n x p data matrix
   # ----- Fill in Defaults -----
   
   if(is.null(args$mgm_par)) args$mgm_par <- TRUE
+  if(is.null(args$tvmgm_par)) args$tvmgm_par <- TRUE
   
   if(is.null(args$lambdaSeq)) args$lambdaSeq <- NULL
   if(is.null(args$lambdaSel)) args$lambdaSel <- 'EBIC'
@@ -163,77 +164,117 @@ tvmgm <- function(data,         # n x p data matrix
   # Storage
   l_tvmgm_models <- list()
   
-  # parallelize mgm
-  if (args$mgm_par){
+  # should we parallelize along the estpoints?
+  if (args$tvmgm_par){
     
-    for(i in 1:no_estpoints) {
-      
-      l_tvmgm_models[[i]] <- mgm.par(data = data,
-                                     type = type,
-                                     level = level,
-                                     lambdaSeq = args$lambdaSeq,
-                                     lambdaSel = args$lambdaSel,
-                                     lambdaFolds = args$lambdaFolds,
-                                     lambdaGam = args$lambdaGam,
-                                     alphaSeq = args$alphaSeq,
-                                     alphaSel = args$alphaSel,
-                                     alphaFolds = args$alphaFolds,
-                                     alphaGam = args$alphaGam,
-                                     k = args$k,
-                                     ruleReg = args$ruleReg,
-                                     weights = l_weights[[i]],
-                                     threshold = args$threshold,
-                                     method = args$method,
-                                     binarySign = args$binarySign,
-                                     scale = args$scale,
-                                     verbatim = args$verbatim,
-                                     pbar = FALSE,
-                                     warnings = args$warnings,
-                                     saveModels = args$saveModels,
-                                     saveData = args$saveData,
-                                     overparameterize = args$overparameterize,
-                                     signInfo = FALSE) # to avoid msg for each model
-  
-      # Update Progress Bar
-      if(args$pbar==TRUE) setTxtProgressBar(pb, i)
-  
-    } # End for: timepoints
-  
+    l_tvmgm_models <- foreach::`%dopar%`(
+      foreach::foreach(i = 1:no_estpoints, .packages = "mgm"),
+      {
+        mgm(data = data,
+            type = type,
+            level = level,
+            lambdaSeq = args$lambdaSeq,
+            lambdaSel = args$lambdaSel,
+            lambdaFolds = args$lambdaFolds,
+            lambdaGam = args$lambdaGam,
+            alphaSeq = args$alphaSeq,
+            alphaSel = args$alphaSel,
+            alphaFolds = args$alphaFolds,
+            alphaGam = args$alphaGam,
+            k = args$k,
+            ruleReg = args$ruleReg,
+            weights = l_weights[[i]],
+            threshold = args$threshold,
+            method = args$method,
+            binarySign = args$binarySign,
+            scale = args$scale,
+            verbatim = args$verbatim,
+            pbar = FALSE,
+            warnings = args$warnings,
+            saveModels = args$saveModels,
+            saveData = args$saveData,
+            overparameterize = args$overparameterize,
+            signInfo = FALSE) # to avoid msg for each model
+        
+      }) # End for: timepoints
+    
   }else{
     
-    # otherwise run each mgm sequentially
-    for(i in 1:no_estpoints) {
+    # otherwise, run inference for est_points sequentially
+  
+    
+    # should we parallelize mgm?
+    if (args$mgm_par){
       
-      l_tvmgm_models[[i]] <- mgm(data = data,
-                                 type = type,
-                                 level = level,
-                                 lambdaSeq = args$lambdaSeq,
-                                 lambdaSel = args$lambdaSel,
-                                 lambdaFolds = args$lambdaFolds,
-                                 lambdaGam = args$lambdaGam,
-                                 alphaSeq = args$alphaSeq,
-                                 alphaSel = args$alphaSel,
-                                 alphaFolds = args$alphaFolds,
-                                 alphaGam = args$alphaGam,
-                                 k = args$k,
-                                 ruleReg = args$ruleReg,
-                                 weights = l_weights[[i]],
-                                 threshold = args$threshold,
-                                 method = args$method,
-                                 binarySign = args$binarySign,
-                                 scale = args$scale,
-                                 verbatim = args$verbatim,
-                                 pbar = FALSE,
-                                 warnings = args$warnings,
-                                 saveModels = args$saveModels,
-                                 saveData = args$saveData,
-                                 overparameterize = args$overparameterize,
-                                 signInfo = FALSE) # to avoid msg for each model
+      for(i in 1:no_estpoints) {
+        
+        l_tvmgm_models[[i]] <- mgm.par(data = data,
+                                       type = type,
+                                       level = level,
+                                       lambdaSeq = args$lambdaSeq,
+                                       lambdaSel = args$lambdaSel,
+                                       lambdaFolds = args$lambdaFolds,
+                                       lambdaGam = args$lambdaGam,
+                                       alphaSeq = args$alphaSeq,
+                                       alphaSel = args$alphaSel,
+                                       alphaFolds = args$alphaFolds,
+                                       alphaGam = args$alphaGam,
+                                       k = args$k,
+                                       ruleReg = args$ruleReg,
+                                       weights = l_weights[[i]],
+                                       threshold = args$threshold,
+                                       method = args$method,
+                                       binarySign = args$binarySign,
+                                       scale = args$scale,
+                                       verbatim = args$verbatim,
+                                       pbar = FALSE,
+                                       warnings = args$warnings,
+                                       saveModels = args$saveModels,
+                                       saveData = args$saveData,
+                                       overparameterize = args$overparameterize,
+                                       signInfo = FALSE) # to avoid msg for each model
+    
+        # Update Progress Bar
+        if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+    
+      } # End for: timepoints
+    
+    }else{
       
-      # Update Progress Bar
-      if(args$pbar==TRUE) setTxtProgressBar(pb, i)
-      
-    } # End for: timepoints
+      # otherwise run each mgm sequentially
+      for(i in 1:no_estpoints) {
+        
+        l_tvmgm_models[[i]] <- mgm(data = data,
+                                   type = type,
+                                   level = level,
+                                   lambdaSeq = args$lambdaSeq,
+                                   lambdaSel = args$lambdaSel,
+                                   lambdaFolds = args$lambdaFolds,
+                                   lambdaGam = args$lambdaGam,
+                                   alphaSeq = args$alphaSeq,
+                                   alphaSel = args$alphaSel,
+                                   alphaFolds = args$alphaFolds,
+                                   alphaGam = args$alphaGam,
+                                   k = args$k,
+                                   ruleReg = args$ruleReg,
+                                   weights = l_weights[[i]],
+                                   threshold = args$threshold,
+                                   method = args$method,
+                                   binarySign = args$binarySign,
+                                   scale = args$scale,
+                                   verbatim = args$verbatim,
+                                   pbar = FALSE,
+                                   warnings = args$warnings,
+                                   saveModels = args$saveModels,
+                                   saveData = args$saveData,
+                                   overparameterize = args$overparameterize,
+                                   signInfo = FALSE) # to avoid msg for each model
+        
+        # Update Progress Bar
+        if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+        
+      } # End for: timepoints
+    }
   }
   
   # Save into output list

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -162,39 +162,42 @@ tvmgm <- function(data,         # n x p data matrix
   # Storage
   l_tvmgm_models <- list()
 
-  for(i in 1:no_estpoints) {
-
-    l_tvmgm_models[[i]] <- mgm(data = data,
-                               type = type,
-                               level = level,
-                               lambdaSeq = args$lambdaSeq,
-                               lambdaSel = args$lambdaSel,
-                               lambdaFolds = args$lambdaFolds,
-                               lambdaGam = args$lambdaGam,
-                               alphaSeq = args$alphaSeq,
-                               alphaSel = args$alphaSel,
-                               alphaFolds = args$alphaFolds,
-                               alphaGam = args$alphaGam,
-                               k = args$k,
-                               ruleReg = args$ruleReg,
-                               weights = l_weights[[i]],
-                               threshold = args$threshold,
-                               method = args$method,
-                               binarySign = args$binarySign,
-                               scale = args$scale,
-                               verbatim = args$verbatim,
-                               pbar = FALSE,
-                               warnings = args$warnings,
-                               saveModels = args$saveModels,
-                               saveData = args$saveData,
-                               overparameterize = args$overparameterize,
-                               signInfo = FALSE) # to avoid msg for each model
+  # for(i in 1:no_estpoints) {
+  l_tvmgm_models <- foreach::`%dopar%`(
+    foreach::foreach(i = 1:no_estpoints, .packages = "mgm"),
+    {
+      # l_tvmgm_models[[i]] <-
+      mgm(data = data,
+          type = type,
+          level = level,
+          lambdaSeq = args$lambdaSeq,
+          lambdaSel = args$lambdaSel,
+          lambdaFolds = args$lambdaFolds,
+          lambdaGam = args$lambdaGam,
+          alphaSeq = args$alphaSeq,
+          alphaSel = args$alphaSel,
+          alphaFolds = args$alphaFolds,
+          alphaGam = args$alphaGam,
+          k = args$k,
+          ruleReg = args$ruleReg,
+          weights = l_weights[[i]],
+          threshold = args$threshold,
+          method = args$method,
+          binarySign = args$binarySign,
+          scale = args$scale,
+          verbatim = args$verbatim,
+          pbar = FALSE,
+          warnings = args$warnings,
+          saveModels = args$saveModels,
+          saveData = args$saveData,
+          overparameterize = args$overparameterize,
+          signInfo = FALSE) # to avoid msg for each model
 
 
     # Update Progress Bar
-    if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+    # if(args$pbar==TRUE) setTxtProgressBar(pb, i)
 
-  } # End for: timepoints
+  }) # End for: timepoints
 
   # Save into output list
   tvmgmobj$tvmodels <- l_tvmgm_models

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -25,7 +25,9 @@ tvmgm <- function(data,         # n x p data matrix
 
 
   # ----- Fill in Defaults -----
-
+  
+  if(is.null(args$mgm_par)) args$mgm_par <- FALSE
+  
   if(is.null(args$lambdaSeq)) args$lambdaSeq <- NULL
   if(is.null(args$lambdaSel)) args$lambdaSel <- 'EBIC'
   if(is.null(args$lambdaFolds)) args$lambdaFolds <- 10
@@ -161,41 +163,78 @@ tvmgm <- function(data,         # n x p data matrix
 
   # Storage
   l_tvmgm_models <- list()
-
-  for(i in 1:no_estpoints) {
-
-    l_tvmgm_models[[i]] <- mgm(data = data,
-                               type = type,
-                               level = level,
-                               lambdaSeq = args$lambdaSeq,
-                               lambdaSel = args$lambdaSel,
-                               lambdaFolds = args$lambdaFolds,
-                               lambdaGam = args$lambdaGam,
-                               alphaSeq = args$alphaSeq,
-                               alphaSel = args$alphaSel,
-                               alphaFolds = args$alphaFolds,
-                               alphaGam = args$alphaGam,
-                               k = args$k,
-                               ruleReg = args$ruleReg,
-                               weights = l_weights[[i]],
-                               threshold = args$threshold,
-                               method = args$method,
-                               binarySign = args$binarySign,
-                               scale = args$scale,
-                               verbatim = args$verbatim,
-                               pbar = FALSE,
-                               warnings = args$warnings,
-                               saveModels = args$saveModels,
-                               saveData = args$saveData,
-                               overparameterize = args$overparameterize,
-                               signInfo = FALSE) # to avoid msg for each model
-
-
-    # Update Progress Bar
-    if(args$pbar==TRUE) setTxtProgressBar(pb, i)
-
-  } # End for: timepoints
-
+  
+  # parallelize mgm
+  if (args$mgm_par){
+    
+    for(i in 1:no_estpoints) {
+      
+      l_tvmgm_models[[i]] <- mgm.par(data = data,
+                                     type = type,
+                                     level = level,
+                                     lambdaSeq = args$lambdaSeq,
+                                     lambdaSel = args$lambdaSel,
+                                     lambdaFolds = args$lambdaFolds,
+                                     lambdaGam = args$lambdaGam,
+                                     alphaSeq = args$alphaSeq,
+                                     alphaSel = args$alphaSel,
+                                     alphaFolds = args$alphaFolds,
+                                     alphaGam = args$alphaGam,
+                                     k = args$k,
+                                     ruleReg = args$ruleReg,
+                                     weights = l_weights[[i]],
+                                     threshold = args$threshold,
+                                     method = args$method,
+                                     binarySign = args$binarySign,
+                                     scale = args$scale,
+                                     verbatim = args$verbatim,
+                                     pbar = FALSE,
+                                     warnings = args$warnings,
+                                     saveModels = args$saveModels,
+                                     saveData = args$saveData,
+                                     overparameterize = args$overparameterize,
+                                     signInfo = FALSE) # to avoid msg for each model
+  
+      # Update Progress Bar
+      if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+  
+    } # End for: timepoints
+  
+  }else{
+    
+    # otherwise, parallelize along the est_points
+    l_tvmgm_models <- foreach::`%dopar%`(
+      foreach::foreach(i = 1:no_estpoints, .packages = "mgm"),
+      {
+        mgm(data = data,
+            type = type,
+            level = level,
+            lambdaSeq = args$lambdaSeq,
+            lambdaSel = args$lambdaSel,
+            lambdaFolds = args$lambdaFolds,
+            lambdaGam = args$lambdaGam,
+            alphaSeq = args$alphaSeq,
+            alphaSel = args$alphaSel,
+            alphaFolds = args$alphaFolds,
+            alphaGam = args$alphaGam,
+            k = args$k,
+            ruleReg = args$ruleReg,
+            weights = l_weights[[i]],
+            threshold = args$threshold,
+            method = args$method,
+            binarySign = args$binarySign,
+            scale = args$scale,
+            verbatim = args$verbatim,
+            pbar = FALSE,
+            warnings = args$warnings,
+            saveModels = args$saveModels,
+            saveData = args$saveData,
+            overparameterize = args$overparameterize,
+            signInfo = FALSE) # to avoid msg for each model
+        
+        }) # End for: timepoints
+    }
+  
   # Save into output list
   tvmgmobj$tvmodels <- l_tvmgm_models
 

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -10,7 +10,9 @@ tvmgm <- function(data,         # n x p data matrix
 )
 
 {
-
+  
+  message("mgm-parallel")
+  
   # -------------------- Input Checks -------------------
 
   args <- list(...)

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -10,8 +10,7 @@ tvmgm <- function(data,         # n x p data matrix
 )
 
 {
-  if (nrow(data) == length(estpoints)) message("mgm-parallel")
-  
+
   # -------------------- Input Checks -------------------
 
   args <- list(...)

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -10,8 +10,7 @@ tvmgm <- function(data,         # n x p data matrix
 )
 
 {
-  
-  message("mgm-parallel")
+  if (nrow(data) == length(estpoints)) message("mgm-parallel")
   
   # -------------------- Input Checks -------------------
 

--- a/R/tvmgm.R
+++ b/R/tvmgm.R
@@ -162,42 +162,39 @@ tvmgm <- function(data,         # n x p data matrix
   # Storage
   l_tvmgm_models <- list()
 
-  # for(i in 1:no_estpoints) {
-  l_tvmgm_models <- foreach::`%dopar%`(
-    foreach::foreach(i = 1:no_estpoints, .packages = "mgm"),
-    {
-      # l_tvmgm_models[[i]] <-
-      mgm(data = data,
-          type = type,
-          level = level,
-          lambdaSeq = args$lambdaSeq,
-          lambdaSel = args$lambdaSel,
-          lambdaFolds = args$lambdaFolds,
-          lambdaGam = args$lambdaGam,
-          alphaSeq = args$alphaSeq,
-          alphaSel = args$alphaSel,
-          alphaFolds = args$alphaFolds,
-          alphaGam = args$alphaGam,
-          k = args$k,
-          ruleReg = args$ruleReg,
-          weights = l_weights[[i]],
-          threshold = args$threshold,
-          method = args$method,
-          binarySign = args$binarySign,
-          scale = args$scale,
-          verbatim = args$verbatim,
-          pbar = FALSE,
-          warnings = args$warnings,
-          saveModels = args$saveModels,
-          saveData = args$saveData,
-          overparameterize = args$overparameterize,
-          signInfo = FALSE) # to avoid msg for each model
+  for(i in 1:no_estpoints) {
+
+    l_tvmgm_models[[i]] <- mgm(data = data,
+                               type = type,
+                               level = level,
+                               lambdaSeq = args$lambdaSeq,
+                               lambdaSel = args$lambdaSel,
+                               lambdaFolds = args$lambdaFolds,
+                               lambdaGam = args$lambdaGam,
+                               alphaSeq = args$alphaSeq,
+                               alphaSel = args$alphaSel,
+                               alphaFolds = args$alphaFolds,
+                               alphaGam = args$alphaGam,
+                               k = args$k,
+                               ruleReg = args$ruleReg,
+                               weights = l_weights[[i]],
+                               threshold = args$threshold,
+                               method = args$method,
+                               binarySign = args$binarySign,
+                               scale = args$scale,
+                               verbatim = args$verbatim,
+                               pbar = FALSE,
+                               warnings = args$warnings,
+                               saveModels = args$saveModels,
+                               saveData = args$saveData,
+                               overparameterize = args$overparameterize,
+                               signInfo = FALSE) # to avoid msg for each model
 
 
     # Update Progress Bar
-    # if(args$pbar==TRUE) setTxtProgressBar(pb, i)
+    if(args$pbar==TRUE) setTxtProgressBar(pb, i)
 
-  }) # End for: timepoints
+  } # End for: timepoints
 
   # Save into output list
   tvmgmobj$tvmodels <- l_tvmgm_models

--- a/bandwidth_candidate_example/examples_tvmgm.R
+++ b/bandwidth_candidate_example/examples_tvmgm.R
@@ -1,0 +1,203 @@
+# ******************************************************************************
+# From https://github.com/jmbh/mgmDocumentation/blob/master/examples_tvmgm.R
+# An example of applying mgm::tvmgm to Gaussian data of dimension 67x150
+# ******************************************************************************
+
+# jonashaslbeck@gmail.com; January 2019
+
+# ----------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------
+# ------------------- Code and Examples: Installation ------------------------------------------------
+# ----------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------
+
+library(mgm) # 1.2-5
+library(qgraph)
+
+# !!! Make sure to set the working directory to the path of the present R-file !!!
+
+figDir <- "figures"
+codeDir <- ""
+fileDir <- "files"
+
+# ----------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------
+# ------------------- Fruit Fly Application: "Time-varying Mixed Graphical Models' -------------------
+# ----------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------
+
+head(fruitfly_data$data[,1:5])
+
+# -------------------- Estimating Bandwidth parameter --------------------
+
+set.seed(1)
+# Note: This can take a while ~1h on a MacBook Pro
+p <- ncol(fruitfly_data$data)
+bw_tvmgm <- bwSelect(data = fruitfly_data$data,
+                     type = rep('g', p),
+                     level = rep(1, p),
+                     bwSeq = c(0.1, 0.2, 0.3, 0.4),
+                     bwFolds = 5,
+                     bwFoldsize = 5,
+                     modeltype = 'mgm', k = 2,
+                     threshold = 'none', ruleReg = 'OR',
+                     timepoints = fruitfly_data$timevector)
+
+# saveRDS(bw_tvmgm, file = paste0(codeDir, "bw_tvmgm.RDS"))
+bw_tvmgm <- readRDS(file = paste0(fileDir, "bw_tvmgm.RDS"))
+
+round(bw_tvmgm$meanError, 3)
+which.min(bw_tvmgm$meanError)
+
+
+# -------------------- Estimating time-varying MGM --------------------
+
+set.seed(1)
+fit_tvmgm <- tvmgm(data = fruitfly_data$data,
+                   type = rep("g", p),
+                   level = rep(1, p),
+                   timepoints = fruitfly_data$timevector,
+                   estpoints = seq(0, 1, length=20),
+                   k = 2,
+                   bandwidth = 0.3,
+                   threshold = "none",
+                   ruleReg = "OR")
+
+# saveRDS(fit_tvmgm, file = paste0(codeDir, 'fit_tvmgm.RDS'))
+fit_tvmgm <- readRDS(file = paste0(fileDir, 'fit_tvmgm.RDS'))
+
+# get wadj
+wadj <- fit_tvmgm$pairwise$wadj
+adj <- wadj
+adj[adj!=0]<-1
+
+# number of edges across estimation points
+n_edges <- apply(adj, 3, sum)/2
+
+
+
+# -------------------- Make Predictions from time-varying MGM --------------------
+
+pred_tvmgm <- predict(object = fit_tvmgm,
+                      data = fruitfly_data$data,
+                      tvMethod = "weighted")
+
+
+# -------------------- Visualizing Mixed Graphical Models --------------------
+
+n <- nrow( fruitfly_data$data)
+estpoints <- seq(0, n, length=20)
+
+# Selected estimation points
+E_select <- c(2, 6, 13)
+round(E_select / 20 * 67, 2) # estimation points on true time scale
+
+## z) Some work on the data
+
+# normalized Time vector
+tv <- fruitfly_data$timevector
+tv <- tv - min(tv)
+tv <- tv / max(tv)
+
+
+# Color shade for Nodes
+wDegree <- list()
+for(i in 1:20)  wDegree[[i]] <- colSums(adj[,,i]) + 1; wDegree[[i]][wDegree[[i]]>9]<-9
+n_color <- max(unlist(wDegree))
+node_cols <- RColorBrewer::brewer.pal(n_color, 'Blues')
+
+
+scale_size <- 1
+pdf(paste0(figDir,'Fig_tvmgm_fruitfly_example.pdf'), width = 10*scale_size, height = 7*scale_size)
+
+# a) Setup Layout
+lom <- matrix(c(1,1,1,
+                2,3,4), ncol=3, byrow = TRUE)
+lo <- layout(lom, heights = c(1, 1))
+# layout.show(lo)
+
+
+# b) Top: Edges/number of observations used over time
+
+# compute proportions of time
+fruitfly_data$stages
+csms <- c(0,cumsum(tv)[c(32, 42, 60, 67)])
+csms <- csms / max(csms)
+
+# Setup plot area
+plot.new()
+par(mar = c(3,3,2,3))
+plot.window(xlim=c(-.02, 1), ylim=c(0,270))
+
+# Set up rectangle-stages
+library(scales)
+col_stagesAlph <- alpha(RColorBrewer::brewer.pal(4, 'Set1'), .3)
+col_stages <- RColorBrewer::brewer.pal(4, 'Set1')
+for(i in 1:4) rect(csms[i], 0, csms[i+1], 250, col = col_stagesAlph[i])
+dash_size <- 5
+title(xlab = 'Estimation Points', cex.lab = 1.5, line=1, col.lab='blue')
+segments(estpoints/67, -dash_size, estpoints/67, +dash_size, col='blue')
+
+# Add time line
+arrows(0, 265, 1, 265, length = .1)
+mtext('Time                                ', 3, srt = 90, col='black')
+mtext('                       / Measurements across time', 3, srt = 90, col='red')
+# Add measurements
+segments(tv, 265-dash_size, tv, 265+dash_size, col='red')
+
+
+# add axis left: (number of edges)
+y_ticks <- c(0, 50, 150, 200, 250)
+tick_horiz <- .01
+for(i in 1:5) {
+  segments(0, y_ticks[i] , -tick_horiz,  y_ticks[i])
+  text(-tick_horiz-.015, y_ticks[i], y_ticks[i])
+}
+mtext('Number of Edges', 2, srt = 90)
+
+
+# add axis right: Proportion used sample size
+y_ticks_labels <- c(0, 25, 50, 67)
+y_ticks <- y_ticks_labels * 250 / 67
+tick_horiz <- .01
+for(i in 1:5) {
+  segments(1, y_ticks[i] , 1+tick_horiz,  y_ticks[i])
+  text(1+tick_horiz+.015, y_ticks[i], y_ticks_labels[i])
+}
+mtext('Local N', 4, srt = 90, line=1.3, col='black')
+
+
+# Add Description of Stages
+shift_left <- .015
+cex_stages <- 1.5
+text(csms[2]-shift_left, 80, 'Embryo', srt=90, cex = cex_stages, col = col_stages[1])
+text(csms[3]-shift_left, 80, 'Larva', srt=90, cex = cex_stages, col = col_stages[2])
+text(csms[4]-shift_left, 190, 'Pupa', srt=90, cex = cex_stages, col = col_stages[3])
+text(csms[5]-shift_left, 190, 'Adult', srt=90, cex = cex_stages, col = col_stages[4])
+
+# Plot data: number of edges
+points(estpoints/67, n_edges, pch=20)
+lines(estpoints/67, n_edges, pch=20)
+
+# Plot data: proportion used Sample size
+rel_y <- 250/67
+points(estpoints/67, fit_tvmgm$Ne*rel_y, pch=21)
+lines(estpoints/67, fit_tvmgm$Ne*rel_y, pch=20, lty=2)
+
+# legend
+legend(.6, 210, c('Number of Edges', 'Local n'), lty=1:2, pch=20:21, bty='n', cex=1.4)
+
+
+# c) Bottom: Graphs at three different time points
+
+# preliminary plotting
+for(i in E_select) qgraph(adj[,,i],
+                          layout='spring',
+                          repulsion=1.05,
+                          labels = F,
+                          # edge.color = fit_tvmgm_nTH$pairwise$edgecolor[,,i],
+                          color = node_cols[wDegree[[i]]],
+                          mar = c(6, 6, 6, 6))
+
+
+dev.off()


### PR DESCRIPTION
Commit 208 shows how mgm can be parallelized, reducing runtime for mgm, tvmgm, and bwSelect:
```
doParallel::registerDoParallel(num_workers)
>   bw <- bwSelect(data = data$X,
+                  type = rep("g", p),
+                  level = rep(1, p),
+                  bwSeq = seq(0.1, 0.4, 0.1),
+                  bwFolds = 5,
+                  bwFoldsize = 5,
+                  modeltype = "mgm",
+                  k = 2,
+                  timepoints = z01)
  |----------------------------------------------------------------------| 100%
bw <- as.numeric(names(which.min(bw$meanError)))
>   out_mgm <- tvmgm(data = data$X,
+                    type = rep("g", p),
+                    level = rep(1, p),
+                    timepoints = z01,
+                    estpoints = z01,
+                    bandwidth = bw,
+                    k = 2,
+                    pbar = T)
```
The remaining 2 commits can be ignored 